### PR TITLE
Utilities to create *html.Node from http.Request and http.Response

### DIFF
--- a/query.go
+++ b/query.go
@@ -91,6 +91,21 @@ func QuerySelectorAll(top *html.Node, selector *xpath.Expr) []*html.Node {
 // LoadURL loads the HTML document from the specified URL.
 func LoadURL(url string) (*html.Node, error) {
 	resp, err := http.Get(url)
+	return handleHttpResponse(resp, err)
+}
+
+// LoadURL loads the HTML document from the specified Request.
+func LoadRequest(request *http.Request) (*html.Node, error) {
+	resp, err := http.DefaultClient.Do(request)
+	return handleHttpResponse(resp, err)
+}
+
+// LoadHttpResponse loads the HTML document from the specified *http.Response.
+func LoadHttpResponse(resp *http.Response) (*html.Node, error) {
+	return handleHttpResponse(resp, nil)
+}
+
+func handleHttpResponse(resp *http.Response, err error) (*html.Node, error) {
 	if err != nil {
 		return nil, err
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -80,6 +80,35 @@ func TestLoadURL(t *testing.T) {
 	}
 }
 
+func TestLoadRequest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, htmlSample)
+	}))
+	defer ts.Close()
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+
+	_, err := LoadRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadHttpResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, htmlSample)
+	}))
+	defer ts.Close()
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	response, _ := http.DefaultClient.Do(request)
+
+	_, err := LoadHttpResponse(response)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestLoadDoc(t *testing.T) {
 	tempHTMLdoc, err := ioutil.TempFile("", "sample_*.html")
 	if err != nil {


### PR DESCRIPTION
I've used this library a few days ago and I was forced to re-implement  in my code LoadURL because my Get request needs customization like custom headers.

Basically there are two new functions:
* LoadHttpResponse: interpret http response like LoadURL, but without make http request;
* LoadRequest: make http request using provided request.