### PR TITLE
Use an interface for LRU cache

### DIFF
--- a/query.go
+++ b/query.go
@@ -49,7 +49,7 @@ func FindOne(top *html.Node, expr string) *html.Node {
 // QueryAll searches the html.Node that matches by the specified XPath expr.
 // Return an error if the expression `expr` cannot be parsed.
 func QueryAll(top *html.Node, expr string) ([]*html.Node, error) {
-	exp, err := getQuery(expr)
+	exp, err := xpcache.GetQuery(expr)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func QueryAll(top *html.Node, expr string) ([]*html.Node, error) {
 //
 // Returns an error if the expression `expr` cannot be parsed.
 func Query(top *html.Node, expr string) (*html.Node, error) {
-	exp, err := getQuery(expr)
+	exp, err := xpcache.GetQuery(expr)
 	if err != nil {
 		return nil, err
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -49,23 +49,24 @@ var testDoc = loadHTML(htmlSample)
 func BenchmarkSelectorCache(b *testing.B) {
 	DisableSelectorCache = false
 	for i := 0; i < b.N; i++ {
-		getQuery("/AAA/BBB/DDD/CCC/EEE/ancestor::*")
+		xpcache.GetQuery("/AAA/BBB/DDD/CCC/EEE/ancestor::*")
 	}
 }
 
 func BenchmarkDisableSelectorCache(b *testing.B) {
 	DisableSelectorCache = true
 	for i := 0; i < b.N; i++ {
-		getQuery("/AAA/BBB/DDD/CCC/EEE/ancestor::*")
+		xpcache.GetQuery("/AAA/BBB/DDD/CCC/EEE/ancestor::*")
 	}
 }
 
 func TestSelectorCache(t *testing.T) {
+	xpcache = NewXpathQueryLookup(2)
 	SelectorCacheMaxEntries = 2
 	for i := 1; i <= 3; i++ {
-		getQuery(fmt.Sprintf("//a[position()=%d]", i))
+		xpcache.GetQuery(fmt.Sprintf("//a[position()=%d]", i))
 	}
-	getQuery("//a[position()=3]")
+	xpcache.GetQuery("//a[position()=3]")
 
 }
 


### PR DESCRIPTION
We're leveraging xpath directly to validate our xquery as well as using htmlquery to do our actual xpath selection. We're using a LRU cache for our direct xpath usage but this means we have one cache for validation and another for htmlquery. 

This PR exposes that cache as an interface which would allow us to not only share the cache but provide alternative cache implementations as well. Performance and behavior remains the same as the current implementation but now the cache is testable, not only that but we can provide null cache operations to improve testability and pre-primed caches.

This small change makes htmlquery a lot more testable and transparent.