### PR TITLE
Bump xpath to 1.3.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/antchfx/htmlquery
 go 1.14
 
 require (
-	github.com/antchfx/xpath v1.3.5
+	github.com/antchfx/xpath v1.3.6
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	golang.org/x/net v0.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/antchfx/xpath v1.3.5 h1:PqbXLC3TkfeZyakF5eeh3NTWEbYl4VHNVeufANzDbKQ=
-github.com/antchfx/xpath v1.3.5/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
+github.com/antchfx/xpath v1.3.6 h1:s0y+ElRRtTQdfHP609qFu0+c6bglDv20pqOViQjjdPI=
+github.com/antchfx/xpath v1.3.6/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
Upgrades to the latest version of xpath so that htmlquery can benefit from bug and security fixes. If you would merge this then I would also suggest tagging a new htmlquery release. Thanks!

Ref. https://github.com/antchfx/xpath/releases/tag/v1.3.6
Previously: https://github.com/antchfx/htmlquery/pull/78

P.S. Please let me know if these kinds of PRs from myself are annoying! This kind of bump is trivial, so maybe you prefer to do it yourself. I'm just interested in htmlquery not falling behind in xpath features. 