### PR TITLE
feat: add LoadURLWithClient to support custom HTTP client

### DIFF
--- a/query.go
+++ b/query.go
@@ -90,15 +90,24 @@ func QuerySelectorAll(top *html.Node, selector *xpath.Expr) []*html.Node {
 	return elems
 }
 
-// LoadURL loads the HTML document from the specified URL. Default enabling gzip on a HTTP request.
+// LoadURL loads the HTML document from the specified URL. Default HTTP Client.
 func LoadURL(url string) (*html.Node, error) {
+	return LoadURLWithClient(url, http.DefaultClient)
+}
+
+// LoadURLWithCustomClient loads the HTML document from the specified URL. Default enabling gzip on a HTTP request.
+// Custom HTTP Client.
+func LoadURLWithClient(url string, client *http.Client)(*html.Node, error){
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
+	if client == nil{
+		client = http.DefaultClient
+	}
 	// Enable gzip compression.
 	req.Header.Add("Accept-Encoding", "gzip")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/antchfx/xpath"
 	"golang.org/x/net/html"
@@ -67,6 +68,28 @@ func TestSelectorCache(t *testing.T) {
 	}
 	getQuery("//a[position()=3]")
 
+}
+
+func TestLoadURLWithClient(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, htmlSample)
+	}))
+	defer ts.Close()
+	cases := []struct {
+		Name string
+		Client *http.Client
+	}{
+		{Name: "Client nil", Client: nil},
+		{Name: "Client Custom", Client: &http.Client{Timeout: 10 * time.Second}},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			_, err := LoadURLWithClient(ts.URL, c.Client)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }
 
 func TestLoadURL(t *testing.T) {


### PR DESCRIPTION
LoadURLWithClient: This function accepts a custom HTTP client to provide greater flexibility when making requests. Why is this needed? The default HTTP client relies on the system's DNS resolvers, which isn't always supported on environments like Android. In those cases, and perhaps many others, a custom dialer and resolver are mandatory. This update gives users the freedom to inject their own configured client if needed